### PR TITLE
Retry po token until valid

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,6 +5,10 @@
     "jsr:@luanrt/googlevideo@2": "2.0.0",
     "jsr:@luanrt/jintr@^3.2.1": "3.2.1",
     "jsr:@std/async@*": "1.0.10",
+    "jsr:@std/encoding@*": "1.0.7",
+    "jsr:@std/fs@*": "1.0.13",
+    "jsr:@std/path@*": "1.0.8",
+    "jsr:@std/path@^1.0.8": "1.0.8",
     "npm:@bufbuild/protobuf@2": "2.2.3",
     "npm:@types/estree@^1.0.6": "1.0.6",
     "npm:@willsoto/node-konfig-core@5.0.0": "5.0.0",
@@ -32,6 +36,18 @@
     },
     "@std/async@1.0.10": {
       "integrity": "2ff1b1c7d33d1416159989b0f69e59ec7ee8cb58510df01e454def2108b3dbec"
+    },
+    "@std/encoding@1.0.7": {
+      "integrity": "f631247c1698fef289f2de9e2a33d571e46133b38d042905e3eac3715030a82d"
+    },
+    "@std/fs@1.0.13": {
+      "integrity": "756d3ff0ade91c9e72b228e8012b6ff00c3d4a4ac9c642c4dac083536bf6c605",
+      "dependencies": [
+        "jsr:@std/path@^1.0.8"
+      ]
+    },
+    "@std/path@1.0.8": {
+      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     }
   },
   "npm": {
@@ -400,6 +416,24 @@
     "https://esm.sh/@types/estree@1.0.6": "https://esm.sh/@types/estree@1.0.6/index.d.ts"
   },
   "remote": {
+    "https://deno.land/std@0.159.0/encoding/ascii85.ts": "f2b9cb8da1a55b3f120d3de2e78ac993183a4fd00dfa9cb03b51cf3a75bc0baa",
+    "https://deno.land/x/brotli@0.1.7/mod.ts": "08b913e51488b6e7fa181f2814b9ad087fdb5520041db0368f8156bfa45fd73e",
+    "https://deno.land/x/brotli@0.1.7/wasm.js": "77771b89e89ec7ff6e3e0939a7fb4f9b166abec3504cec0532ad5c127d6f35d2",
+    "https://deno.land/x/crypto@v0.10.1/aes.ts": "0f4e5af07514a07d56ec01b2186c0153f13d6e00c26fc4e70692996af6280e48",
+    "https://deno.land/x/crypto@v0.10.1/block-modes.ts": "a7ef359649a2cf235451e80aed7a5fda612d92ca2b158bf2a724b32899f8e455",
+    "https://deno.land/x/crypto@v0.10.1/src/aes/consts.ts": "582aeed7afda2fe3deac4a60c4a9f29c60a7fb66f56645f95fa0ddab49bde994",
+    "https://deno.land/x/crypto@v0.10.1/src/aes/mod.ts": "883d1e48d033dc4491f3a336c07235c5c4cb0371972476b8cdeea5e94ad2efbe",
+    "https://deno.land/x/crypto@v0.10.1/src/block-modes/base.ts": "9006474c676782602ede9ea16aa49e8d084fd5670f6050641715a3d3085e1ba5",
+    "https://deno.land/x/crypto@v0.10.1/src/block-modes/cbc.ts": "ce1ae944dd1912febd1d69c26c3a4ba18caeac9544ac3c62abd8b2429842de19",
+    "https://deno.land/x/crypto@v0.10.1/src/block-modes/cfb.ts": "a1de2d9b81c0333be6c8d005019db1f4b2956264f8f0f93e7e51e8059ad16147",
+    "https://deno.land/x/crypto@v0.10.1/src/block-modes/ctr.ts": "06fd8e338dbda0a6a7fa49718a0fd247830759820e61646a6cf611ad69a9d464",
+    "https://deno.land/x/crypto@v0.10.1/src/block-modes/ecb.ts": "c346d692f16f8efbcc041c25dd761ca223ef92e03bb05457908953bf261ba325",
+    "https://deno.land/x/crypto@v0.10.1/src/block-modes/mod.ts": "bb7e3ddafa15b1ca024b4b5013b23d134410d01e90ce3d5be5489eb9d5f601c5",
+    "https://deno.land/x/crypto@v0.10.1/src/block-modes/ofb.ts": "0f77075505853b4ba1a55b4edecb17323f8a1489456a3d3b74717565cccbf2ef",
+    "https://deno.land/x/crypto@v0.10.1/src/utils/bytes.ts": "7ccf6cb2d747d9b9de04c9a2494999957c1e86fd4e14bc228aad25283323f5a0",
+    "https://deno.land/x/crypto@v0.10.1/src/utils/padding.ts": "544c51a471a413b15940bf08b285bc6a5db27796ff3cf240564f42701aba01dc",
+    "https://deno.land/x/lz4@v0.1.2/mod.ts": "4decfc1a3569d03fd1813bd39128b71c8f082850fe98ecfdde20025772916582",
+    "https://deno.land/x/lz4@v0.1.2/wasm.js": "b9c65605327ba273f0c76a6dc596ec534d4cda0f0225d7a94ebc606782319e46",
     "https://esm.sh/@bufbuild/protobuf@2.0.0/denonext/dist/esm/create.mjs": "d9fcaeb3dfeb517c4d59843d78d7b51b3ad91b911e35bc317dc29e97e4ba9e67",
     "https://esm.sh/@bufbuild/protobuf@2.0.0/denonext/dist/esm/descriptors.mjs": "7e5dd304539ba1889dea236a3635983d22038ae19bd4952d1d9323f1622a9aaa",
     "https://esm.sh/@bufbuild/protobuf@2.0.0/denonext/dist/esm/from-binary.mjs": "8619f1c113211c1bfde08795f2a8f30faeb6b48fefecf044dd12580bdd77e176",

--- a/src/lib/helpers/youtubePlayerHandling.ts
+++ b/src/lib/helpers/youtubePlayerHandling.ts
@@ -25,11 +25,11 @@ export const youtubePlayerParsing = async ({
     tokenMinter,
     overrideCache = false,
 }: {
-    innertubeClient: Innertube,
-    videoId: string,
-    konfigStore: Store,
-    tokenMinter: BG.WebPoMinter,
-    overrideCache?: boolean,
+    innertubeClient: Innertube;
+    videoId: string;
+    konfigStore: Store;
+    tokenMinter: BG.WebPoMinter;
+    overrideCache?: boolean;
 }): Promise<object> => {
     const cacheEnabled = konfigStore.get("cache.enabled");
 
@@ -150,7 +150,8 @@ export const youtubePlayerParsing = async ({
         }))(videoData);
 
         if (
-            cacheEnabled && !overrideCache && videoData.playabilityStatus?.status == "OK"
+            cacheEnabled && !overrideCache &&
+            videoData.playabilityStatus?.status == "OK"
         ) {
             (async () => {
                 await kv.set(

--- a/src/lib/helpers/youtubePlayerHandling.ts
+++ b/src/lib/helpers/youtubePlayerHandling.ts
@@ -31,12 +31,12 @@ export const youtubePlayerParsing = async ({
     tokenMinter: BG.WebPoMinter;
     overrideCache?: boolean;
 }): Promise<object> => {
-    const cacheEnabled = konfigStore.get("cache.enabled");
+    const cacheEnabled = konfigStore.get("cache.enabled") && !overrideCache;
 
     const videoCached = (await kv.get(["video_cache", videoId]))
         .value as Uint8Array;
 
-    if (videoCached != null && cacheEnabled && !overrideCache) {
+    if (videoCached != null && cacheEnabled) {
         return JSON.parse(new TextDecoder().decode(decompress(videoCached)));
     } else {
         const youtubePlayerResponse = await youtubePlayerReq(
@@ -149,10 +149,7 @@ export const youtubePlayerParsing = async ({
             },
         }))(videoData);
 
-        if (
-            cacheEnabled && !overrideCache &&
-            videoData.playabilityStatus?.status == "OK"
-        ) {
+        if (cacheEnabled && videoData.playabilityStatus?.status == "OK") {
             (async () => {
                 await kv.set(
                     ["video_cache", videoId],

--- a/src/lib/helpers/youtubePlayerHandling.ts
+++ b/src/lib/helpers/youtubePlayerHandling.ts
@@ -31,7 +31,7 @@ export const youtubePlayerParsing = async ({
     tokenMinter: BG.WebPoMinter;
     overrideCache?: boolean;
 }): Promise<object> => {
-    const cacheEnabled = konfigStore.get("cache.enabled") && !overrideCache;
+    const cacheEnabled = overrideCache ? false : konfigStore.get("cache.enabled");
 
     const videoCached = (await kv.get(["video_cache", videoId]))
         .value as Uint8Array;

--- a/src/lib/helpers/youtubePlayerHandling.ts
+++ b/src/lib/helpers/youtubePlayerHandling.ts
@@ -18,18 +18,25 @@ const { youtubePlayerReq } = await import(youtubePlayerReqLocation);
 
 const kv = await Deno.openKv();
 
-export const youtubePlayerParsing = async (
+export const youtubePlayerParsing = async ({
+    innertubeClient,
+    videoId,
+    konfigStore,
+    tokenMinter,
+    overrideCache = false,
+}: {
     innertubeClient: Innertube,
     videoId: string,
     konfigStore: Store,
     tokenMinter: BG.WebPoMinter,
-): Promise<object> => {
+    overrideCache?: boolean,
+}): Promise<object> => {
     const cacheEnabled = konfigStore.get("cache.enabled");
 
     const videoCached = (await kv.get(["video_cache", videoId]))
         .value as Uint8Array;
 
-    if (videoCached != null && cacheEnabled == true) {
+    if (videoCached != null && cacheEnabled && !overrideCache) {
         return JSON.parse(new TextDecoder().decode(decompress(videoCached)));
     } else {
         const youtubePlayerResponse = await youtubePlayerReq(
@@ -143,7 +150,7 @@ export const youtubePlayerParsing = async (
         }))(videoData);
 
         if (
-            cacheEnabled == true && videoData.playabilityStatus?.status == "OK"
+            cacheEnabled && !overrideCache && videoData.playabilityStatus?.status == "OK"
         ) {
             (async () => {
                 await kv.set(

--- a/src/lib/jobs/potoken.ts
+++ b/src/lib/jobs/potoken.ts
@@ -149,20 +149,17 @@ export const poTokenGenerate = async (
             throw new Error("no videos with id found in trending");
         }
 
-        const cacheEnabled = konfigStore.get("cache.enabled");
-        // disable cache duing call to youtubePlayerParsing to avoid poisoning cache with a bad PO token
-        konfigStore.set("cache.enabled", false);
-        const youtubePlayerResponseJson = await youtubePlayerParsing(
-            instantiatedInnertubeClient,
-            video.id,
+        const youtubePlayerResponseJson = await youtubePlayerParsing({
+            innertubeClient: instantiatedInnertubeClient,
+            videoId: video.id,
             konfigStore,
-            integrityTokenBasedMinter,
-        );
+            tokenMinter: integrityTokenBasedMinter,
+            overrideCache: true,
+        });
         const videoInfo = youtubeVideoInfo(
             instantiatedInnertubeClient,
             youtubePlayerResponseJson,
         );
-        konfigStore.set("cache.enabled", cacheEnabled);
         const validFormat = videoInfo.streaming_data?.adaptive_formats[0];
         if (!validFormat) {
             throw new Error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { Innertube, UniversalCache } from "youtubei.js";
 import { poTokenGenerate } from "./lib/jobs/potoken.ts";
 import { USER_AGENT } from "bgutils";
 import { konfigLoader } from "./lib/helpers/konfigLoader.ts";
+import { retry } from "jsr:@std/async";
 import type { HonoVariables } from "./lib/types/HonoVariables.ts";
 import type { BG } from "bgutils";
 
@@ -87,15 +88,20 @@ innertubeClient = await Innertube.create({
 
 if (!innertubeClientOauthEnabled) {
     if (innertubeClientJobPoTokenEnabled) {
-        ({ innertubeClient, tokenMinter } = await poTokenGenerate(
-            innertubeClient,
-            konfigStore,
-            innertubeClientCache as UniversalCache,
+        ({ innertubeClient, tokenMinter } = await retry(
+            poTokenGenerate.bind(
+                poTokenGenerate,
+                innertubeClient,
+                konfigStore,
+                innertubeClientCache as UniversalCache,
+            ),
+            { minTimeout: 1_000, maxTimeout: 60_000, multiplier: 5, jitter: 0 },
         ));
     }
     Deno.cron(
         "regenerate youtube session",
         konfigStore.get("jobs.youtube_session.frequency") as string,
+        { backoffSchedule: [5_000, 15_000, 60_000, 180_000] },
         async () => {
             if (innertubeClientJobPoTokenEnabled) {
                 ({ innertubeClient, tokenMinter } = await poTokenGenerate(

--- a/src/routes/invidious_routes/dashManifest.ts
+++ b/src/routes/invidious_routes/dashManifest.ts
@@ -29,12 +29,12 @@ dashManifest.get("/:videoId", async (c) => {
         }
     }
 
-    const youtubePlayerResponseJson = await youtubePlayerParsing(
+    const youtubePlayerResponseJson = await youtubePlayerParsing({
         innertubeClient,
         videoId,
         konfigStore,
-        c.get("tokenMinter"),
-    );
+        tokenMinter: c.get("tokenMinter"),
+    });
     const videoInfo = youtubeVideoInfo(
         innertubeClient,
         youtubePlayerResponseJson,

--- a/src/routes/invidious_routes/latestVersion.ts
+++ b/src/routes/invidious_routes/latestVersion.ts
@@ -33,12 +33,12 @@ latestVersion.get("/", async (c) => {
         }
     }
 
-    const youtubePlayerResponseJson = await youtubePlayerParsing(
+    const youtubePlayerResponseJson = await youtubePlayerParsing({
         innertubeClient,
-        id,
+        videoId: id,
         konfigStore,
-        c.get("tokenMinter"),
-    );
+        tokenMinter: c.get("tokenMinter"),
+    });
     const videoInfo = youtubeVideoInfo(
         innertubeClient,
         youtubePlayerResponseJson,

--- a/src/routes/youtube_api_routes/player.ts
+++ b/src/routes/youtube_api_routes/player.ts
@@ -9,12 +9,12 @@ player.post("/player", async (c) => {
     const konfigStore = c.get("konfigStore");
     if (jsonReq.videoId) {
         return c.json(
-            await youtubePlayerParsing(
+            await youtubePlayerParsing({
                 innertubeClient,
-                jsonReq.videoId,
+                videoId: jsonReq.videoId,
                 konfigStore,
-                c.get("tokenMinter"),
-            ),
+                tokenMinter: c.get("tokenMinter"),
+            }),
         );
     }
 });


### PR DESCRIPTION
Adds a video check & retry on the PO token job to tackle ~ 1 in 8 tokens being non-viable.

The setup at this point will hold off starting hono and the cron job until it manages to successfully generate a PO token. This uses the deno `retry` inbuilt to back off and handle errors multiple times.

Once that's done, the cron-job retry is implemented using the inbuilt backoff logic available in deno's cron module:
https://docs.deno.com/deploy/kv/manual/cron/#retrying-failed-runs

The deno cron handler ensures that backoffs don't cause issues with overlapping jobs: https://docs.deno.com/deploy/kv/manual/cron/#overlapping-executions


I haven't added any config for these backoff intervals - I figure it probably makes most sense to define some sensible defaults for now and then look at the potential for configurability down the road. 

The logic for checking a "random" video is as follows:
1. get the trending videos through innertubes' `getTrending` function
2. filter to `type === 'video'` on the resulting list
3. shuffle the array to make sure we're not getting the same video every time
4. find the first video with an ID in the resulting array
5. get the first item from the streaming_data.adaptive_formats array
6. `fetch` the URL with a `HEAD` request

There's no point in time where invidious-companion will use a PO token that it knows to be bad. Only once all checks have passed with the PO token be overwritten and the new Content PO token minter be passed back.

Note that this also briefly disables the cache in order to call `youtubePlayerParsing` without poisoning the cache with URLs that 403. It resets the cache back to the previous value after the call, ensuring the cache won't be switched on if it's configured to be off. 

